### PR TITLE
errors: exit on error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -37,6 +37,13 @@ module.exports.init = function(app, config){
              * is Serene's timeout value.
              */
             app.logger.warn('\nCLEANUP reason : %s code: %s', label, code);
+            
+            /*
+             * For now, we are ignoring the code, since
+             * exit(0) ensures that our app gets restarted
+             * by docker.
+             */
+            process.exit(0);
         });
     }
 


### PR DESCRIPTION
This closes #14 by forcing the process to exit with error after we calling `app.close`.