### PR TITLE
Add timeout to resolve promise. Added resolveTimeout option

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -190,6 +190,14 @@ const DEFAULTS = {
         commands: './commands'
     },
 
+    /**
+     * Time in seconds aftwer which we reject
+     * a call to `context.resolve`.
+     *
+     * @type {Number}
+     */
+    resolveTimeout: 10 * 1000,
+
     config: {}
 };
 
@@ -756,16 +764,18 @@ class Application extends EventEmitter {
 
         var instance = this[id];
 
-        //TODO: Test...
-        // if(instance === undefined) {
-        //     return Promise.reject(id);
-        // }
-
         if(instance) {
             return Promise.resolve(this[id]);
         }
 
         return new Promise((resolve, reject) => {
+
+            let tid = setTimeout(() => {
+                let msg = `Call to resolve("${id}") timed out after ${this.resolveTimeout/1000}s.`;
+                this.logger.error(msg);
+                reject(new Error(msg));
+            }, this.resolveTimeout);
+
             this.once(id + '.' + this.registerReadyEvent, (instance) => {
                 resolve(this[id]);
             });


### PR DESCRIPTION
This closes #34 by adding a timeout handler in the `resolve(id)` call. If a module has not been registered with the given id after `resolveTimeout` has passed the promise will be rejected. 

We set `resolveTimeout` to 10s by default. This might vary in a next update.