### PR TITLE
Add timeout to register function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -13,6 +13,8 @@ const extend = require('gextend');
 const Keypath = require('gkeypath');
 const EventEmitter = require('events');
 const PluginLoader = require('in');
+const timeoutPromise = require('p-timeout');
+
 const pkg = require('../package.json');
 
 const sanitizeName = require('./utils').sanitizeName;
@@ -197,6 +199,14 @@ const DEFAULTS = {
      * @type {Number}
      */
     resolveTimeout: 10 * 1000,
+
+    /**
+     * Time in seconds aftwer which we reject
+     * a call to `context.register`.
+     *
+     * @type {Number}
+     */
+    registerTimeout: 10 * 1000,
 
     config: {}
 };
@@ -539,10 +549,10 @@ class Application extends EventEmitter {
             context.emit(name + '.' + context.registerReadyEvent, out);
         }
 
-        //TODO: setTimeout to ensure we are not waiting for ever...
-        //require('p-timeout')(delayedPromise, 50).then(() => 'foo');
-        Promise.resolve(out).then((module) => {
+        timeoutPromise(Promise.resolve(out), this.registerTimeout).then((module) => {
+
             _register(this, name, module);
+
         }).catch(this.onErrorHandler.bind(this, true, 'register: Error registering module ' + name));
     }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "in": "^0.10.*",
     "longjohn": "^0.2.12",
     "noop-console": "^0.4.0",
+    "p-timeout": "^1.1.1",
     "poke-repl": "^0.8.0",
     "simple-config-loader": "^0.10",
     "verror": "^1.10.0",


### PR DESCRIPTION
This closes #23. The new behavior will timeout a call to `context.register` if the returned promise has not been resolved in less than `registerTimeout`.