### PR TITLE
Extend commands

### DIFF
--- a/examples/commands/media.upload.js
+++ b/examples/commands/media.upload.js
@@ -1,0 +1,10 @@
+'use strict';
+
+class MediaUploadCommand {
+
+    execute(event){
+        event.context.getLogger('media').info('execute media upload command...');
+    }
+}
+
+module.exports = MediaUploadCommand;

--- a/lib/application.js
+++ b/lib/application.js
@@ -24,7 +24,7 @@ const getModuleName = require('./utils').getModuleName;
 const getListenerCount = require('./utils').getListenerCount;
 const fullStack = require('./utils').fullStack;
 const _isFunction = require('./utils').isFunction;
-
+const _normalizeCommandObject = require('./utils').normalizeCommandObject
 /**
  * Default values for the options object
  * used to initialize an Application instance.
@@ -985,13 +985,27 @@ class Application extends EventEmitter {
      * Command handler functions get bound to
      * the application context.
      *
-     * @param  {String} eventType   Event type
-     * @param  {Function} handler Command handler
+     * We can ensure that a given `eventType`
+     * executes a single command by setting
+     * `unique` to true.
+     *
+     * @param  {String}   eventType       Event type
+     * @param  {Function} handler        Command handler
+     * @param  {Boolean}  [unique=false] Register a single command
+     *                                   for a given eventType
      * @return {this}
      */
-    command(eventType, handler) {
+    command(eventType, handler, unique=false) {
         this._logger.debug('- register handler for %s', eventType);
-        handler = handler.bind(this);
+
+        let command = _normalizeCommandObject(handler);
+
+        handler = command.execute.bind(this);
+
+        if(unique && this.listeners(type).length > 0) {
+            this._logger.warn('- %s has a listener registered and marked as unique', eventType);
+            return this;
+        }
 
         this.on(eventType, (e) => {
             this.logger.warn('Execute command for %s', eventType);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,6 +75,27 @@ function getListenerCount(emitter, type) {
     return listeners === -1 ? 0 : listeners;
 }
 
+/**
+ * Normalize command object.
+ * @param  {Mixed} command
+ * @param  {Object} [config={}]
+ * @return {Object}
+ */
+function normalizeCommandObject(command, config={}){
+    if(command.execute) {
+        return command;
+    } else if(command.prototype.execute) {
+        return new command(config);
+    }
+
+    /*
+     * we assume we have a function.
+     * Check!!
+     */
+    return {
+        execute: command
+    };
+}
 
 const VError = require('verror');
 
@@ -113,3 +134,12 @@ module.exports.getPathToMain = getPathToMain;
  * @exports getListenerCount
  */
 module.exports.getListenerCount = getListenerCount;
+
+
+/**
+ * Normalize command object
+ *
+ * @type {Function}
+ * @exports getListenerCount
+ */
+module.exports.normalizeCommandObject = normalizeCommandObject;


### PR DESCRIPTION
This closes #43 by adding support for command classes. We normalize the event handler to a command object.

Now `app.command(<eventType>, <handler>);` accepts the following handlers:

```js
class Command {
  execute(event){}
}
module.exports = Command;
```

```js
function CommandFunction(event){
}

module.exports = CommandFunction;
```
