### PR TITLE
Update configuration options

### DIFF
--- a/examples/cli.js
+++ b/examples/cli.js
@@ -13,8 +13,20 @@ const config = Application.loadConfig({
     globOptions: {
         matchPatterh: '+(app.js|pubsub.js)',
         ignorePattern: 'index.js'
-    }
+    },
+    loadModulesOptions: ['pubsub']
 }, true);
 
 console.log(Object.keys(config));
 console.log(config.coremodules);
+
+const app = new Application({config});
+
+app.once('run.complete', function(e) {
+    app.logger.debug('>> run.complete: ');
+    app.logger.debug('some info %s', Object.keys(app.config));
+});
+
+app.once('coreplugins.ready', ()=>{
+    app.run();
+});

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Application = require('..').Application;
+
+/*
+ * We want to load a subset of the
+ * total application.
+ * - Ignore some core modules.
+ * - Ignore most modules.
+ */
+const config = Application.loadConfig({
+    coremodules: ['./logger'],
+    globOptions: {
+        matchPatterh: '+(app.js|pubsub.js)',
+        ignorePattern: 'index.js'
+    }
+}, true);
+
+console.log(Object.keys(config));
+console.log(config.coremodules);

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -6,7 +6,7 @@ const Application = require('..').Application;
  * We want to load a subset of the
  * total application.
  * - Ignore some core modules.
- * - Ignore most modules.
+ * - Ignore most modules, load pubusb only.
  */
 const config = Application.loadConfig({
     coremodules: ['./logger'],

--- a/examples/config/app.js
+++ b/examples/config/app.js
@@ -8,5 +8,8 @@ module.exports = {
     loaders: {
         modules: './modules',
         commands: './commands'
+    },
+    loadModulesOptions: {
+        only: ['transform', 'pubsub']
     }
 };

--- a/examples/index.js
+++ b/examples/index.js
@@ -24,7 +24,7 @@ app.onceRegistered('logger', () => {
 
 app.once('run.complete', function(e) {
     app.logger.debug('>> run.complete: ');
-    app.logger.debug('some info %s', JSON.stringify(app.config, null, 4));
+    app.logger.debug('some info %s', Object.keys(app.config));
 });
 
 app.once('run.pre', function(e){

--- a/lib/application.js
+++ b/lib/application.js
@@ -817,8 +817,9 @@ class Application extends EventEmitter {
 
     loadModules(dir='modules', options={}) {
         this._mountedPaths.set(dir, true);
-        _makeExcludeFilterFromWantList(options);
         
+        _makeExcludeFilterFromWantList(options);
+
         return this.loader.mountDirectory(dir, {
             exclude: options.only,
             afterMount: (context)=>{

--- a/lib/application.js
+++ b/lib/application.js
@@ -1063,6 +1063,7 @@ class Application extends EventEmitter {
         if(!options.projectpath) options.projectpath = process.cwd();
 
         const configLoader = require('simple-config-loader');
+
         /*
          * First we can to load options we might have
          * here, at the core library.
@@ -1074,17 +1075,47 @@ class Application extends EventEmitter {
         options = extend({}, DEFAULTS, libDefaults.data, options);
 
         let projectpath = options.projectpath;
+
         delete options.projectpath;
+
+        let loaderOptions = {
+            config: options,
+            basepath: projectpath,
+            packagePath: projectpath + '/package'
+        };
+
+        /*
+         * Our namespace is a little bit dirty :(
+         * This is a list of keywords that if
+         * present in the `options` object we
+         * will pick and pass along with the
+         * loader's options object.
+         *
+         * The rest of keys found in the original
+         * options object are passed to the
+         * loaders `options.config` object which
+         * in turn is the default data for the
+         * returned configuration object.
+         */
+        let pickKeywords = [
+            'dirname',
+            'globOptions',
+            'getConfigFiles',
+            'getPackage',
+            'configsPath'
+        ];
+
+        pickKeywords.forEach((key)=>{
+            if(!options[key]) return;
+            loaderOptions[key] = options[key];
+            options[key] = undefined;
+        });
 
         /*
          * Now, load configurations found on the project's
          * directory.
          */
-        var config = configLoader({
-            config: options,
-            basepath: projectpath,
-            packagePath: projectpath + '/package'
-        });
+        let config = configLoader(loaderOptions);
 
         if(asObject) return config._target;
         return config;

--- a/lib/application.js
+++ b/lib/application.js
@@ -1113,7 +1113,7 @@ class Application extends EventEmitter {
         pickKeywords.forEach((key)=>{
             if(!options[key]) return;
             loaderOptions[key] = options[key];
-            options[key] = undefined;
+            delete options[key];
         });
 
         /*

--- a/lib/application.js
+++ b/lib/application.js
@@ -18,6 +18,7 @@ const timeoutPromise = require('p-timeout');
 
 const pkg = require('../package.json');
 
+const _makeExcludeFilterFromWantList = require('./utils').makeExcludeFilterFromWantList;
 const sanitizeName = require('./utils').sanitizeName;
 const getPathToMain = require('./utils').getPathToMain;
 const getModuleName = require('./utils').getModuleName;
@@ -463,7 +464,7 @@ class Application extends EventEmitter {
             .then(() => {
                 return this.loadCommands(this.commandspath);
             }).then(() => {
-                return this.loadModules(this.modulespath);
+                return this.loadModules(this.modulespath, this.loadModulesOptions);
             }).catch(this.onErrorHandler.bind(this, true, 'Error loading plugin.'));
     }
 
@@ -788,7 +789,11 @@ class Application extends EventEmitter {
     }
 
     loadModules(dir='modules', options={}) {
+
+        _makeExcludeFilterFromWantList(options);
+
         return this.loader.mountDirectory(dir, {
+            exclude: options.only,
             afterMount: (context)=>{
                 this.emit('modules.ready');
             }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,30 @@
 const path = require('path');
 
 /**
+ * Transform a list of files we want into
+ * a pattern for multimatch that would
+ * exclude files NOT matching those names.
+ *
+ * @param  {Object} options
+ * @return {Object}
+ */
+function makeExcludeFilterFromWantList(options){
+    if(options.only) {
+
+        if(!Array.isArray(options.only)) {
+            options.only = [options.only];
+        }
+        /*
+         * multimatch pattern to exclude all files
+         * except literal matches by name.
+         */
+        options.only = ['**', `!**/+(${options.only.join('|')}).js`];
+    }
+
+    return options;
+}
+
+/**
  * Naive filename sanitize function.
  *
  * @link https://github.com/parshap/node-sanitize-filename
@@ -113,3 +137,5 @@ module.exports.getPathToMain = getPathToMain;
  * @exports getListenerCount
  */
 module.exports.getListenerCount = getListenerCount;
+
+module.exports.makeExcludeFilterFromWantList = makeExcludeFilterFromWantList;


### PR DESCRIPTION
We can now select which modules to load from the **modules/** directory- instead of autoloading all modules found in it.

You need to add a `loadModulesOptions` attribute to the `config/app.js` configuration file.
It should be an array with the names of modules you want to load. Note that at the moment you would need to list modules and their dependencies.

```js
module.exports = {
  loadModulesOptions: {
        only: ['transform', 'pubsub']
    }
};
```

(misleading branch name)