### PR TITLE
Fixes

### DIFF
--- a/examples/cli.js
+++ b/examples/cli.js
@@ -9,12 +9,30 @@ const Application = require('..').Application;
  * - Ignore most modules, load pubusb only.
  */
 const config = Application.loadConfig({
-    coremodules: ['./logger'],
+    /*
+     * To override application-core specific
+     * configuration options we need to wrap
+     * them here.
+     */
+    app: {
+        coremodules: ['./logger'],
+        loadModulesOptions: {
+            only: ['pubsub']
+        }
+    },
+    /*
+     * Available options to override
+     * simple-config-loader:
+     * - dirname
+     * - globOptions
+     * - getConfigFiles
+     * - getPackage
+     * - configsPath
+     */
     globOptions: {
         matchPatterh: '+(app.js|pubsub.js)',
         ignorePattern: 'index.js'
-    },
-    loadModulesOptions: ['pubsub']
+    }
 }, true);
 
 const app = new Application({config});

--- a/examples/cli.js
+++ b/examples/cli.js
@@ -15,7 +15,7 @@ const config = Application.loadConfig({
      * them here.
      */
     app: {
-        coremodules: ['./logger'],
+        coremodules: ['./logger', './dispatcher'],
         loadModulesOptions: {
             only: ['pubsub']
         }
@@ -35,13 +35,14 @@ const config = Application.loadConfig({
     }
 }, true);
 
+
 const app = new Application({config});
 
-app.once('run.complete', function(e) {
-    app.logger.debug('>> run.complete: ');
-    app.logger.debug('some info %s', Object.keys(app.config));
+app.once('run.post', function(e) {
+    app.logger.warn('>> run.complete: ');
+    app.logger.warn('some info %s', Object.keys(app.config));
 });
 
-app.once('coreplugins.ready', ()=>{
+app.once('modules.ready', ()=>{
     app.run();
 });

--- a/examples/config/app.js
+++ b/examples/config/app.js
@@ -8,8 +8,5 @@ module.exports = {
     loaders: {
         modules: './modules',
         commands: './commands'
-    },
-    loadModulesOptions: {
-        only: ['transform', 'pubsub']
     }
 };

--- a/lib/application.js
+++ b/lib/application.js
@@ -57,6 +57,10 @@ const DEFAULTS = {
      */
     logger: console,
 
+    getLogger: function() {
+        return console;
+    },
+
     /**
      * This will hold the **core** child
      * logger used by the framework to report
@@ -817,7 +821,7 @@ class Application extends EventEmitter {
 
     loadModules(dir='modules', options={}) {
         this._mountedPaths.set(dir, true);
-        
+
         _makeExcludeFilterFromWantList(options);
 
         return this.loader.mountDirectory(dir, {
@@ -960,12 +964,14 @@ class Application extends EventEmitter {
          */
         this.once(`logger.${this.registerReadyEvent}`, ()=>{
             this.loader.logger = this.getLogger('modules');
-            this.logger.info('Application Version: ' + pkg.version);
-            this.logger.info('Application Environment: ' + process.env.NODE_ENV);
         });
 
         this.once('modules.ready', ()=>{
             this._logger.debug('Modules loaded...');
+
+            this.logger.info('Application Version: ' + pkg.version);
+            this.logger.info('Application Environment: ' + this.environment);
+
             let time = (process.uptime()).toFixed(3);
             this._logger.debug('Application took %ss to boot...', time, {
                 __meta__: {
@@ -985,7 +991,7 @@ class Application extends EventEmitter {
          * it to be registered before we can call it :)
          */
         if(!this.hook) {
-            this.once(`coreplugins.${this.registerReadyEvent}`, this.run);
+            this.once(`coreplugins.ready`, this.run);
             return;
         }
 

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -11,7 +11,7 @@ module.exports.init = function(app, config) {
 
     app.hook = createHook(app);
 
-    app.getLogger('dispatcher').debug('Module "dispatcher" ready...');
+    app.getLogger('dispatcher').info('Module "dispatcher" ready...');
 
     /**
      * @TODO This is not necessary! remove


### PR DESCRIPTION
This closes #47 by using `coreplugins.ready` instead of `coreplugins.${this.registerReadyEvent}`.
It adds a `getLogger` default function to work on #48.