### PR TITLE
Check we have basepath in config.app during load options

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1164,6 +1164,10 @@ class Application extends EventEmitter {
         if(!options.basepath) options.basepath = getPathToMain();
         if(!options.projectpath) options.projectpath = process.cwd();
 
+        if(!Keypath.get(options, 'app.basepath', false)){
+            Keypath.set(options, 'app.basepath', options.basepath);
+        }
+
         const configLoader = require('simple-config-loader');
 
         /*


### PR DESCRIPTION
This closes #33 by adding a check before preloading config files.