### PR TITLE
remove logger.debug calls, use info instead

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -26,7 +26,8 @@ const getModuleName = require('./utils').getModuleName;
 const getListenerCount = require('./utils').getListenerCount;
 const fullStack = require('./utils').fullStack;
 const _isFunction = require('./utils').isFunction;
-const _normalizeCommandObject = require('./utils').normalizeCommandObject
+const _normalizeCommandObject = require('./utils').normalizeCommandObject;
+
 /**
  * Default values for the options object
  * used to initialize an Application instance.
@@ -851,7 +852,7 @@ class Application extends EventEmitter {
             },
             afterMount: (context) => {
                 this.emit('commands.ready');
-                context._logger.debug('Commands from dir "%s" loaded...', dir);
+                context._logger.info('Commands from dir "%s" loaded...', dir);
             }
         }).catch((err) => {
             this.onErrorHandler(true, 'Error loading commands.', err);
@@ -950,17 +951,17 @@ class Application extends EventEmitter {
     _registerListeners() {
         this.once('run.pre', ()=>{
             let listeners = getListenerCount(this, 'run.pre');
-            this._logger.debug('Running "pre" stage of "run" hook: %s listeners.', listeners);
+            this._logger.info('Running "pre" stage of "run" hook: %s listeners.', listeners);
         });
 
         this.once('run', ()=> {
             let listeners = getListenerCount(this, 'run');
-            this._logger.debug('Running "run" hook: %s listeners.', listeners);
+            this._logger.info('Running "run" hook: %s listeners.', listeners);
         });
 
         this.once('run.post', ()=>{
             let listeners = getListenerCount(this, 'run.post');
-            this._logger.debug('Running "post" stage of "run" hook: %s listeners.', listeners);
+            this._logger.info('Running "post" stage of "run" hook: %s listeners.', listeners);
         });
 
         /*
@@ -973,13 +974,13 @@ class Application extends EventEmitter {
         });
 
         this.once('modules.ready', ()=>{
-            this._logger.debug('Modules loaded...');
+            this._logger.info('Modules loaded...');
 
             this.logger.info('Application Version: ' + pkg.version);
             this.logger.info('Application Environment: ' + this.environment);
 
             let time = (process.uptime()).toFixed(3);
-            this._logger.debug('Application took %ss to boot...', time, {
+            this._logger.info('Application took %ss to boot...', time, {
                 __meta__: {
                     style: 'bold+white+magenta_bg'
                 }
@@ -1006,7 +1007,7 @@ class Application extends EventEmitter {
 
         // this.logger.profile('hook:run');
         this.hook('run', {name: this.name}).then(()=>{
-            this._logger.debug('Hook "run" complete.');
+            this._logger.info('Hook "run" complete.');
             this.registerApplication();
         });
     }
@@ -1018,7 +1019,7 @@ class Application extends EventEmitter {
      * @return {void}
      */
     registerApplication(register=true){
-        this._logger.debug('Register application...', this.registration);
+        this._logger.info('Register application...', this.registration);
 
         let options = extend({data:{}}, this.defaultRegistrationData(), this.registration);
 
@@ -1036,7 +1037,7 @@ class Application extends EventEmitter {
         }
 
         options.register = register;
-        this._logger.debug('options...', options);
+        this._logger.info('options...', options);
 
         if(_isFunction(this.registry)) {
             return this.registry(this, options);
@@ -1080,7 +1081,7 @@ class Application extends EventEmitter {
      * @return {this}
      */
     command(eventType, handler, unique=false) {
-        this._logger.debug('- register handler for %s', eventType);
+        this._logger.info('- register handler for %s', eventType);
 
         let command = _normalizeCommandObject(handler);
 


### PR DESCRIPTION
This closes #48 by removing all references to `logger.debug`. If we don't load the logger module we use the _default_ logger- the standard `console` object- which does not have a `debug` method.

We could patch the console:
```js
console.debug = console.info;
```

But it's rather ugly...