### PR TITLE
Fix 56 add getLogger to child loggers

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -88,6 +88,12 @@ module.exports.init = function(app, config) {
         var logger = new (winston.Logger)(options);
 
         /*
+         * Expose the getLogger function
+         * through child loggers.
+         */
+        logger.getLogger = getLogger;
+
+        /*
          * We don't want to register a listener for
          * each logger instance. We do it once for
          * the core logger.


### PR DESCRIPTION
This closes #56 by adding `getLogger` to child loggers. We can now do the following:

```js
const logger = context.getLogger('my-module');
const child = logger.getLogger('my-child');
let sub = new SubModule({logger: child});
```