### PR TITLE
Update poke repl

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -47,18 +47,15 @@ module.exports.init = function(context, config){
         context.emit('repl.ready', repl);
 
         /**
-         * the application context changed, 
+         * the application context changed,
          * we should reload the connection.
-         * 
-         * There should be a repl command to 
+         *
+         * There should be a repl command to
          * reload/refresh the connection.
          */
         context.on('context.invalidated', ()=>{
             _logger.info('Update content invalidated. Reload REPL module');
-            //TODO: this should be encapsulated to 
-            //repl.updateContext('app', context, true);
-            repl.context.app = context;
-            // repl.refreshClients();
+            repl.updateContext('app', context);
         });
     });
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "longjohn": "^0.2.12",
     "noop-console": "^0.4.0",
     "p-timeout": "^1.1.1",
-    "poke-repl": "^0.8.0",
+    "poke-repl": "^0.9.*",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
     "simple-config-loader": "^0.10",


### PR DESCRIPTION
Updated poke-repl version to latest, we can now update our repl context and clients will have the latest version of the app. This is useful during development to support hot module reloading- update models, make them available in the REPL.