### PR TITLE
Name process using either app nicename or app config option processName

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -34,7 +34,7 @@ const _normalizeCommandObject = require('./utils').normalizeCommandObject;
  * used to initialize an Application instance.
  *
  * It's not meant to be used directly.
- * 
+ *
  *
  * @TODO Create default banner :)
  *
@@ -47,9 +47,9 @@ const DEFAULTS = {
      * This is used for instance to enable
      * long stack traces using
      * the longjohn module.
-     * 
+     *
      * @todo Should we set to production?
-     * 
+     *
      * @memberof Application
      * @instance
      * @default development
@@ -60,9 +60,9 @@ const DEFAULTS = {
     /**
      * This will hold the **app** child
      * logger used by the applciation
-     * instance. The output will be 
+     * instance. The output will be
      * identified with the **app** id.
-     * 
+     *
      * @memberof Application
      * @instance
      * @type {Logger}
@@ -71,15 +71,15 @@ const DEFAULTS = {
 
     /**
      * Default implementation of a logger
-     * factory that is provided by the 
-     * logger module. Needed to ensure we 
+     * factory that is provided by the
+     * logger module. Needed to ensure we
      * can run applications if we decide to
      * not load the logger module.
-     * 
+     *
      * @example
      * context.getLogger('my-module').info('hi');
-     * 
-     * @memberof Application 
+     *
+     * @memberof Application
      * @instance
      * @param {String} name Child logger indentifier
      * @return {Logger} A child logger instance.
@@ -119,7 +119,7 @@ const DEFAULTS = {
      * instance and delay the boot cycle
      * by initializeing the instance with
      * this value set to `false`.
-     *     
+     *
      * @memberof Application
      * @instance
      * @default true
@@ -131,7 +131,7 @@ const DEFAULTS = {
      * If a module has a `commands`
      *
      * @memberof Application
-     * @instance 
+     * @instance
      * @type {Boolean}
      */
     autoloadModulesCommands: false,
@@ -142,7 +142,7 @@ const DEFAULTS = {
      * prompt or by the logger module to create
      * a child logger asigned to the application
      * context.
-     * 
+     *
      * @memberof Application
      * @instance
      * @default
@@ -155,7 +155,7 @@ const DEFAULTS = {
      * will `process.exit` the application.
      *
      * @memberof Application
-     * @instance 
+     * @instance
      * @default true
      * @type {Boolean}
      */
@@ -199,7 +199,7 @@ const DEFAULTS = {
      * application instance will emit an event.
      * The event type is:
      * <moduleName>.<registerReadyEvent>
-     * 
+     *
      * @memberof Application
      * @instance
      * @default registered
@@ -250,7 +250,7 @@ const DEFAULTS = {
      * Default paths to load commands
      * and modules. Relative to application
      * path.
-     * 
+     *
      * @memberof Application
      * @instance
      * @type {Object}
@@ -288,7 +288,7 @@ const DEFAULTS = {
     registerTimeout: 10 * 1000,
 
     /**
-     * 
+     *
      * @memberof Application
      * @instance
      */
@@ -340,9 +340,9 @@ const DEFAULTS = {
      * This function will register the
      * current applciation instance with
      * the core.io application registry.
-     * 
+     *
      * @instance
-     * @memberof Application 
+     * @memberof Application
      */
     registry: require('./registry')
 };
@@ -410,6 +410,7 @@ class Application extends EventEmitter {
          */
         this._registerListeners();
         this._configure();
+        this._nameProcess();
         this._setupLongStackTraces();
         this._showBanner();
         this._mount();
@@ -468,11 +469,27 @@ class Application extends EventEmitter {
     _configure() {
         /*
          * This is not the most elegant solution
-         * but... ¯\_(ツ)_/
+         * but... ¯\_(ツ)_/¯
          */
         if (this.config.app) extend(this, this.config.app);
 
         this.config = Keypath.wrap(this.config, null, 'data');
+    }
+
+    /**
+     * Set the process name to either the
+     * application's `nicename` or to the
+     * value of `config.app.processName`.
+     *
+     * @private
+     * @return {void}
+     */
+    _nameProcess() {
+        if(this.config.app.processName) {
+            process.title = this.config.app.processName;
+        } else {
+            process.title = this.nicename;
+        }
     }
 
     /**
@@ -844,7 +861,7 @@ class Application extends EventEmitter {
      * before we do here, our module needs to attach
      * it's error listener before returning the module
      * to App core.
-     * 
+     *
      * @throws {Error} Will retrhow the error from here.
      * @param  {String} moduleId Module name
      * @param  {Error} err      Error object
@@ -1016,13 +1033,13 @@ class Application extends EventEmitter {
      * If after `context.resolveTimeout` milliseconds the
      * module has not been registered the promise will be
      * rejected.
-     * 
+     *
      * If `id` is `undefined` this method will
      * throw an Error.
-     * If we are trying to resolve a set of dependencies 
-     * that might or might not be there you can pass 
+     * If we are trying to resolve a set of dependencies
+     * that might or might not be there you can pass
      * `ignoreUndefinedIds` as true to not generate an error.
-     * This might be the case if we are loading optional 
+     * This might be the case if we are loading optional
      * dependencies from a user configuration file
      *
      * @param  {String|Array} id Module id
@@ -1035,8 +1052,8 @@ class Application extends EventEmitter {
 
         if (!id) {
             /*
-             * We are dealing with optional 
-             * dependecies. 
+             * We are dealing with optional
+             * dependecies.
              */
             if (ignoreUndefinedIds) {
                 return Promise.resolve();
@@ -1284,13 +1301,13 @@ class Application extends EventEmitter {
 
     /**
      * Sanitized version of the given name.
-     * It will remove starting digits, and camel 
+     * It will remove starting digits, and camel
      * case it.
-     * 
+     *
      * @type {String}
      */
     get nicename() {
-        return sanitizeName(this._name);
+        return sanitizeName(this.name || this.config.app);
     }
 
     get modulespath() {
@@ -1316,7 +1333,7 @@ class Application extends EventEmitter {
     /**
      * Convenience method to load configuration
      * objects.
-     * 
+     *
      * This uses the [simple-config-loader](http://github.com/goliatone/simple-config-loader) package
      * to load, merge, and resolve all configuration files
      * found in `options.dirname`.
@@ -1331,7 +1348,7 @@ class Application extends EventEmitter {
      * @param  {Object}   options.globOptions Options object used to match and ignore files.
      * @param  {String}   [options.globOptions.matchPatterh='**.js']
      * @param  {String}   [options.globOptions.ignorePattern='index.js']
-     * @param  {Function}   options.getConfigFiles Function to collect configuration files. 
+     * @param  {Function}   options.getConfigFiles Function to collect configuration files.
      *                                             Uses `glob` under the hood.
      * @param  {Function}  options.getPackage   Function to retrieve package.json
      * @param  {String}   [options.configsPath='./']


### PR DESCRIPTION
We can now name our running process using a configuration option:
* `config.app.processName`

If not present, we use `app.nicename`.