### PR TITLE
Fix 67

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1492,7 +1492,7 @@ class Application extends EventEmitter {
      */
     static loadConfig(options = {}, asObject = true) {
         if (!options.basepath) options.basepath = getPathToMain();
-        if (!options.projectpath) options.projectpath = process.cwd();
+        if (!options.projectpath) options.projectpath = getPathToMain();
 
         if (!Keypath.get(options, 'app.basepath', false)) {
             Keypath.set(options, 'app.basepath', options.basepath);
@@ -1547,11 +1547,34 @@ class Application extends EventEmitter {
             delete options[key];
         });
 
+        /**
+         * If we are running our script from
+         * outside the project directory we 
+         * should cd into it so that paths
+         * behave as expected :)
+         */
+        if (process.cwd() !== projectpath) {
+            process.chdir(projectpath);
+        }
+
         /*
          * Now, load configurations found on the project's
          * directory.
          */
-        let config = configLoader(loaderOptions);
+        let config;
+
+        try {
+            config = configLoader(loaderOptions);
+        } catch (error) {
+            console.error('\n');
+            console.error('Error loading project configuration files.');
+            console.error('Project path: %s', projectpath);
+            console.error('Main path: %s', getPathToMain());
+            console.error('CWD path: %s', process.cwd());
+            console.error('\n');
+            console.error(error);
+            process.exit(1);
+        }
 
         if (asObject) return config._target;
         return config;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "poke-repl": "^0.10.*",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
-    "simple-config-loader": "^0.10.*",
+    "simple-config-loader": "^0.11.*",
     "verror": "^1.10.0",
     "winston": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gkeypath": "^0.7.*",
     "glob": "^7.1.2",
     "human-time": "0.0.1",
-    "in": "^0.13.*",
+    "in": "^0.14.*",
     "longjohn": "^0.2.12",
     "noop-console": "*",
     "p-timeout": "^1.1.1",


### PR DESCRIPTION
This closes #67 by doing a `chdir` to our defined project path so that relative paths behave as expected.