### PR TITLE
Reload commands

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -24,7 +24,8 @@
     "plusplus": false,
     "node": true,
     "esversion": 6,
-    "globals":{
+    "es6": true,
+    "globals": {
         "describe": true,
         "it": true
     }

--- a/examples/commands/run.js
+++ b/examples/commands/run.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function runHanlder(){
+module.exports = function runHanlder(context) {
     this.logger.warn('runHandler: Running application!!');
     this.getLogger('transform').info('Calling transform logger from runHandler');
 };

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,5 +8,7 @@
   },
   "author": "",
   "license": "ISC",
-  "dependencies": {}
+  "dependencies": {
+    "chokidar": "^3.0.2"
+  }
 }

--- a/lib/application.js
+++ b/lib/application.js
@@ -419,8 +419,7 @@ class Application extends EventEmitter {
         this._commands = [];
         this._registering = [];
         this._mountedPaths = new Map();
-        this._commandTypes = [];
-
+        this._commandHandlers = {};
         /*
          * We want our listeners to be the first
          * ones added
@@ -462,9 +461,11 @@ class Application extends EventEmitter {
 
         /*
          * Too early to use the logger module.
+         * TODO: replace with process.stdout.write()
          */
         if (typeof this.banner === 'string') {
-            console.log(this.banner);
+            // console.log(this.banner);
+            process.stdout.write(this.banner + '\n');
         }
 
         if (_isFunction(this.banner)) {
@@ -1019,7 +1020,6 @@ class Application extends EventEmitter {
     async loadCommands(dir = 'commands', options = {}) {
         this._mountedPaths.set(dir, true);
 
-        // if (!fs.existsSync(dir)) {
         if (!await exists(dir)) {
             this.logger.warn('directory ENOENT for loadCommands(%s)', dir);
             return Promise.resolve();
@@ -1029,7 +1029,8 @@ class Application extends EventEmitter {
             mountHandler: (bean, context, config = {}) => {
                 //TODO: This might have to be a unique, 
                 // context.command(bean.id, bean.plugin, true);
-                context.command(bean.id, bean.plugin);
+                context.command(bean.id, bean.plugin, bean.path);
+
                 return bean.plugin;
             },
             afterMount: (context) => {
@@ -1126,7 +1127,7 @@ class Application extends EventEmitter {
         }
 
         if (Array.isArray(id)) {
-            return Promise.all(id.map((i) => this.resolve(i)));
+            return Promise.all(id.map(i => this.resolve(i)));
         }
 
         /*
@@ -1146,6 +1147,7 @@ class Application extends EventEmitter {
                 reject(new Error(msg));
             }, this.resolveTimeout);
 
+            //TODO: Shouldn't we resolve(instance) here?!
             this.once(id + '.' + this.registerReadyEvent, instance => {
                 clearTimeout(tid);
                 resolve(this[id]);
@@ -1314,24 +1316,27 @@ class Application extends EventEmitter {
      * 
      * @param  {String}   eventType       Event type
      * @param  {Function} handler        Command handler
+     * @param  {String}   id             Handler unique identifier
      * @param  {Boolean}  [unique=false] Register a single command
      *                                   for a given eventType
      * @return {this}
      */
-    command(eventType, handler, unique = false) {
+    command(eventType, handler, id, unique = false) {
         this._logger.debug('- register handler for %s', eventType);
+
+        if (!id) id = this.getUid();
 
         let command = _normalizeCommandObject(handler);
 
         handler = command.execute.bind(this);
 
-        if (unique && this.listeners(eventType).length > 0) {
+        if (unique && this.hasCommand(eventType)) {
             this._logger.warn('- %s has a listener registered and marked as unique', eventType);
             return this;
         }
 
-        this.on(eventType, (e = {}) => {
-            this.logger.debug('Execute command for %s', eventType);
+        const commandHandler = (e = {}) => {
+            this.logger.debug('Executing command: "%s"', eventType);
 
             e = this.makeEventForCommand(eventType, e);
 
@@ -1367,9 +1372,11 @@ class Application extends EventEmitter {
                 this.logger.error('Error executing command "%s".', eventType);
                 this.logger.error(err);
             });
-        });
+        };
 
-        this._commandTypes.push(eventType);
+        this.on(eventType, commandHandler);
+
+        this._commandHandlers[id] = { eventType, commandHandler, unique };
 
         return this;
     }
@@ -1381,7 +1388,21 @@ class Application extends EventEmitter {
      * @returns {Boolean}
      */
     hasCommand(type) {
-        return this._commandTypes.includes(type);
+        return this.listeners(type).length > 0;
+    }
+
+    /**
+     * Replaces a command handler. We need to provide
+     * the `id` used during when we registered the 
+     * command.
+     * 
+     * @param {String} id Command handler identifier
+     * @param {Function} handler New handler
+     */
+    reloadCommand(id, handler) {
+        const { eventType, commandHandler, unique } = this._commandHandlers[id];
+        let out = this.removeListener(eventType, commandHandler);
+        return this.command(eventType, handler, id, unique);
     }
 
     /**

--- a/lib/application.js
+++ b/lib/application.js
@@ -1200,6 +1200,7 @@ class Application extends EventEmitter {
             this._logger.debug('Modules loaded...', style);
             this._logger.debug('Core Version: %s', pkg.version, style);
             this._logger.debug('Environment: %s', this.environment, style);
+            this._logger.debug('Application PID %s', process.pid);
             this._logger.debug('Application took %ss to boot...', time, style);
         });
 


### PR DESCRIPTION
This closes #77 adding support for reloading commands.

* Added `reloadCommand` method.
* Refactored `command` method: added an `id` parameter that we use to call `reloadCommand`.
* Updated example to include a snippet using `chikidar` to hot reload commands when we edit the file.