### PR TITLE
Add `getUid` prefix string

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -174,15 +174,23 @@ function normalizeCommandObject(command, config = {}) {
  * @param {Number} len Output length
  * @return {String}
  */
-function getUid(len = 20) {
+function getUid(len = 20, prefix = '') {
+    if (typeof len === 'string') {
+        if (arguments.length === 1) prefix = len, len = 20;
+        else if (arguments.length === 2)[prefix, len] = arguments;
+    }
+
     const timestamp = (new Date()).getTime().toString(36);
 
-    const randomString = (len) => [...Array(len)].map(() => Math.random().toString(36)[3]).join('');
+    const randomString = len => [...Array(len)].map(_ => Math.random().toString(36)[3]).join('');
 
-    len = len - (timestamp.length + 1);
+    len = Math.max(5, len - (timestamp.length + 1));
+
+    if (prefix) return `${prefix}-${timestamp}-${randomString(len)}`;
 
     return `${timestamp}-${randomString(len)}`;
 }
+
 
 const VError = require('verror');
 

--- a/tests/application-spec.js
+++ b/tests/application-spec.js
@@ -119,7 +119,7 @@ test('Banner can be a function, called with app instance and config object', (t)
     t.end();
 });
 
-test('_configure should extend the applciation instance with config.app', (t) => {
+test('_configure should extend the application instance with config.app', (t) => {
     let NOOP = function() {};
     let expected = { name: 'TestApp', testing: true };
 
@@ -138,7 +138,7 @@ test('_configure should extend the applciation instance with config.app', (t) =>
     t.end();
 });
 
-test('_configure should wrap "config" in Keypath utility', (t) => {
+test('_configure should wrap "config" in KeyPath utility', (t) => {
     let NOOP = function() {};
     let expected = { name: 'TestApp', testing: true };
 

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -1,10 +1,12 @@
 'use strict';
 const test = require('tape');
 
-const utils = require('../lib/utils');
-const sanitizeName = utils.sanitizeName;
-const getModuleName = utils.getModuleName;
-const getPathToMain = utils.getPathToMain;
+const {
+    getUid,
+    sanitizeName,
+    getModuleName,
+    getPathToMain,
+} = require('../lib/utils');
 
 // Application.DEFAULTS.autoinitialize = false;
 
@@ -30,5 +32,66 @@ test('getModuleName given a path should return the name of a file', (t) => {
 
 test('getPathToMain should return the path to main process file', (t) => {
     t.ok(getPathToMain(), getPathToMain());
+    t.end();
+});
+
+test('getUid should return a string of length 20 by default', (t) => {
+    const expected = 20;
+    t.equals(
+        getUid().length,
+        expected,
+        'default length'
+    );
+
+    t.end();
+});
+
+test('getUid should return a string of min length 14', (t) => {
+    const expected = 14;
+
+    t.equals(
+        getUid(1).length,
+        expected,
+        'default min length'
+    );
+
+    t.end();
+});
+
+test('getUid should append a prefix which does not count for length', (t) => {
+    const prefix = 'test';
+    const expected = prefix.length + 1 + 14;
+
+    t.equals(
+        getUid(1, prefix).length,
+        expected,
+        'prefixed uid'
+    );
+
+    t.end();
+});
+
+test('getUid should accept swapping arguments', (t) => {
+    const prefix = 'test';
+
+    t.equals(
+        getUid(10, prefix).length,
+        getUid(prefix, 10).length,
+        'swapping arguments'
+    );
+
+    t.end();
+});
+
+test('getUid should accept only prefix argument', (t) => {
+    const prefix = 'test';
+    const expected = prefix.length + 1 + 20;
+
+    t.equals(
+        getUid(prefix).length,
+        expected,
+        'swapping arguments'
+    );
+
     t.end();
 });


### PR DESCRIPTION
This closes #97 by adding a `prefix` argument to `getUid`.