### PR TITLE
Add deprecation helper

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -10,7 +10,7 @@
 const os = require('os');
 const path = require('path');
 const extend = require('gextend');
-const Keypath = require('gkeypath');
+const KeyPath = require('gkeypath');
 const EventEmitter = require('events');
 const PluginLoader = require('in');
 const timeoutPromise = require('p-timeout');
@@ -63,7 +63,7 @@ const DEFAULTS = {
 
     /**
      * This will hold the **app** child
-     * logger used by the applciation
+     * logger used by the application
      * instance. The output will be
      * identified with the **app** id.
      *
@@ -85,7 +85,7 @@ const DEFAULTS = {
      *
      * @memberof Application
      * @instance
-     * @param {String} name Child logger indentifier
+     * @param {String} name Child logger identifier
      * @return {Logger} A child logger instance.
      */
     getLogger: function(name) {
@@ -116,12 +116,12 @@ const DEFAULTS = {
      */
     autorun: false,
     /**
-     * Initialize the applciation from
+     * Initialize the application from
      * the constructor call?
      *
      * You can create an application
      * instance and delay the boot cycle
-     * by initializeing the instance with
+     * by initializing the instance with
      * this value set to `false`.
      *
      * @memberof Application
@@ -144,7 +144,7 @@ const DEFAULTS = {
      * Name of the application instance.
      * Used by the REPL module to display the
      * prompt or by the logger module to create
-     * a child logger asigned to the application
+     * a child logger assigned to the application
      * context.
      *
      * @memberof Application
@@ -179,7 +179,7 @@ const DEFAULTS = {
      * @default true
      * @type {Boolean}
      */
-    enableLongStackTrackes: true,
+    enableLongStackTraces: true,
 
     /**
      * Function to sanitize module
@@ -242,7 +242,7 @@ const DEFAULTS = {
      * need to be loaded by the application
      * instance.
      *
-     * Defualts to current working directory
+     * Defaults to current working directory
      * of the Node.js process.
      *
      * @memberof Application
@@ -267,7 +267,7 @@ const DEFAULTS = {
     },
 
     /**
-     * Time in seconds aftwer which we reject
+     * Time in seconds after which we reject
      * a call to `context.resolve`.
      *
      * If we set it too low we might not give
@@ -284,7 +284,7 @@ const DEFAULTS = {
     resolveTimeout: 40 * 1000,
 
     /**
-     * Time in seconds aftwer which we reject
+     * Time in seconds after which we reject
      * a call to `context.register`.
      *
      * @memberof Application
@@ -375,7 +375,7 @@ const DEFAULTS = {
     },
     /*
      * This function will register the
-     * current applciation instance with
+     * current application instance with
      * the core.io application registry.
      *
      * @instance
@@ -432,7 +432,7 @@ class Application extends EventEmitter {
      * Initializes the instance by:
      * - Registering event listeners
      * - Configuring the application instance
-     * - Setup long statck traces
+     * - Setup long stack traces
      * - Show ASCII banner
      * - Mount modules
      *
@@ -471,7 +471,7 @@ class Application extends EventEmitter {
 
     /**
      * Shows a banner on cli.
-     * A banner is just text outputed to
+     * A banner is just text outputted to
      * the console, which supports ASCII
      * formatting.
      *
@@ -501,7 +501,6 @@ class Application extends EventEmitter {
          * TODO: replace with process.stdout.write()
          */
         if (typeof this.banner === 'string') {
-            // console.log(this.banner);
             this.bannerOut(this.banner);
         }
 
@@ -514,7 +513,7 @@ class Application extends EventEmitter {
      * This step will extend the application
      * instance with contents from `./config/app.js`.
      *
-     * It creates a Keypath wrapped object
+     * It creates a KeyPath wrapped object
      * of the configuration object, and exposes it
      * under `config`.
      *
@@ -528,7 +527,7 @@ class Application extends EventEmitter {
          */
         if (this.config.app) extend(this, this.config.app);
 
-        this.config = Keypath.wrap(this.config, null, 'data');
+        this.config = KeyPath.wrap(this.config, null, 'data');
     }
 
     /**
@@ -549,7 +548,7 @@ class Application extends EventEmitter {
 
     /**
      * Enables long stack traces with
-     * `longjohn`, helpful for debuging.
+     * `longjohn`, helpful for debugging.
      * Disabled in production.
      *
      * @private
@@ -570,7 +569,7 @@ class Application extends EventEmitter {
         /*
          * Enable long stack traces
          */
-        if (this.enableLongStackTrackes) {
+        if (this.enableLongStackTraces) {
             require('longjohn');
         }
     }
@@ -584,7 +583,7 @@ class Application extends EventEmitter {
      *
      * @emits Application#coreplugins.ready
      * @emits Application#logger.registered
-     * @throws {Error } Will throw if an error ocurs while loading
+     * @throws {Error } Will throw if an error occurs while loading
      *         a module.
      * @private
      * @return {void}
@@ -605,10 +604,11 @@ class Application extends EventEmitter {
                 context._logger.debug('Mount Handler: module "%s" mounted...', bean.id);
                 context.register(bean.plugin, bean.id);
 
-                //TODO: we might want to check options for autoload
-                //commands. Maybe we want to override provided commands
-                //of a module with our own... to do so we need to be able
-                //to access options from name
+                /**
+                 * Add modules commands to the command path loader.
+                 * This will make them available as if they were in the 
+                 * main command path.
+                 */
                 if (await context._moduleHasCommands(bean)) {
                     context._logger.warn('Plugin "%s" has commands', bean.id);
                     this._commands.push(bean.path);
@@ -642,7 +642,7 @@ class Application extends EventEmitter {
      * Due to the mount process and auto-wiring,
      * `name` will often times refer to a npm
      * package name or a file name. Basically
-     * anyting that can be `require`d.
+     * anything that can be `require`d.
      *
      * This function will:
      * - Normalize `name`: ensure name is a valid
@@ -672,7 +672,7 @@ class Application extends EventEmitter {
      * - Once `instance` is resolved, the function will
      *   assign a child logger to it.
      * - If it does not have an `moduleid` property it
-     *   will assing `name`.
+     *   will assign `name`.
      * - If instance extends EventEmitter it will register
      *   `handleModuleError` as an **error** listener.
      *
@@ -732,11 +732,11 @@ class Application extends EventEmitter {
         }
 
         /**
-         * TODO: We want to autoload commands if available!
+         * TODO: We want to auto-load commands if available!
          */
         if (instance.commands) {
             this._logger.warn('IMPLEMENT HANDLER FOR plugin.commands!');
-            //our plugin exposes a bunch of comand paths
+            //our plugin exposes a bunch of command paths
             // if(typeof instance.commands === 'string') instance.commands = [instance.commands];
             // if(typeof instance.commands === 'function') instance.commands = instance.commands();
             // this._commands = this._commands.concat(instance.commands);
@@ -752,19 +752,24 @@ class Application extends EventEmitter {
 
         /*
          * This is the process to register our modules.
-         * @TODO Move to inclass private method.
+         * @TODO Move to in-class private method.
          */
         function _register(context, name, instance) {
             if (instance !== false) context._registerInstance(name, instance);
             //FIX: This might be too late, we want to make it available
             //during the initialization phase of the module.
             //We can pass it in the config.
+
             if (context.getLogger) {
                 instance.logger = context.getLogger(name);
             }
+
             if (!instance.moduleid) instance.moduleid = name;
 
-            //TODO: Figure out a better way to manage errors.
+            /**
+             * If our module is an instance of EventEmitter
+             * capture error events.
+             */
             if (_isFunction(instance.on)) {
                 instance.on('error', context.handleModuleError.bind(context, name));
             }
@@ -830,7 +835,7 @@ class Application extends EventEmitter {
      *
      * @param  {String} attr      Attribute name
      *
-     * @param  {Mixed} extension Funtion or value
+     * @param  {Mixed} extension Function or value
      *
      * @throws This will throw a TypeError if we
      *         are trying to overwrite a previously
@@ -1142,7 +1147,7 @@ class Application extends EventEmitter {
      * that might or might not be there you can pass
      * `ignoreUndefinedIds` as true to not generate an error.
      * This might be the case if we are loading optional
-     * dependencies from a user configuration file
+     * dependencies from a user configuration file.
      *
      * @param  {String|Array} id Module id
      * @param  {Boolean} [ignoreUndefinedIds=false] Wether to ignore undefined ids.
@@ -1307,7 +1312,7 @@ class Application extends EventEmitter {
          * We can register our application with a
          * service to keep track of instances.
          * There are different implementations
-         * such as a local mdns or an HTTP service
+         * such as a local MDNS or an HTTP service
          * like the core.io registry.
          */
         if (_isFunction(this.registry)) {
@@ -1625,8 +1630,8 @@ class Application extends EventEmitter {
         if (!options.basepath) options.basepath = getPathToMain();
         if (!options.projectpath) options.projectpath = getPathToMain();
 
-        if (!Keypath.get(options, 'app.basepath', false)) {
-            Keypath.set(options, 'app.basepath', options.basepath);
+        if (!KeyPath.get(options, 'app.basepath', false)) {
+            KeyPath.set(options, 'app.basepath', options.basepath);
         }
 
         const configLoader = require('simple-config-loader');

--- a/lib/deprecation.js
+++ b/lib/deprecation.js
@@ -1,0 +1,84 @@
+function getLineInfo(lineInfo) {
+    lineInfo = lineInfo.replace(/^.*\s\(/, '').replace(/\)$/, '');
+    let [file, line, position] = lineInfo.split(':');
+    return { file, line: line - 1, position: +position };
+}
+
+function getFileLine(filename, line) {
+    const fs = require('fs');
+    let data = fs.readFileSync(filename, 'utf8');
+    let lines = data.split('\n');
+
+    if (line > lines.length) {
+        throw new Error('File end reached without finding line');
+    }
+
+    return lines[line];
+}
+
+class DeprecationError extends Error {
+    constructor(attribute, type) {
+        super(`${type} ${attribute} is deprecated`);
+        this.type = type;
+        this.attribute = attribute;
+        let { stack, fileInfo } = this._getStack();
+        this.stack = stack;
+        this.fileInfo = fileInfo;
+
+    }
+
+    getSource() {
+        return getFileLine(this.fileInfo.file, this.fileInfo.line);
+    }
+
+    _getStack() {
+        let stack = (new Error()).stack;
+        stack = stack.split(' at ');
+        stack = [stack[0], ...stack.slice(5)];
+
+        let fileInfo = getLineInfo(stack[1]);
+        let source = getFileLine(fileInfo.file, fileInfo.line);
+
+        stack = stack.join('at ');
+        stack = stack.replace(/^Error/, `Deprecation Notice:\n   -> ${source}`);
+
+        return { stack, fileInfo };
+    }
+}
+
+module.exports = DeprecationError;
+
+/*
+const context = {
+    moduleid: 'test'
+};
+
+function markAsDeprecated(instance, attribute) {
+    const old = instance[attribute];
+    Object.defineProperty(instance, attribute, {
+        get: function $get() {
+            context.deprecationNotice(attribute, 'attribute');
+            return old;
+        },
+    });
+}
+
+function functionUsingDeprecatedAttribute() {
+    console.log('module id: %s', context.moduleid);
+}
+
+
+function main() {
+    context.deprecationNotice = deprecationNotice;
+    markAsDeprecated(context, 'moduleid');
+    functionUsingDeprecatedAttribute();
+}
+
+function deprecationNotice(attribute, type) {
+    let error = new DeprecationError(attribute, type);
+    console.log(error.getSource());
+    console.log(error.stack);
+}
+
+main();
+*/

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,19 +56,24 @@ function makeExcludeFilterFromWantList(options = {}) {
  *
  * @memberof core/utils
  * @param  {String} [name=''] Name to be clean up
+ * @param  {Boolean} [legacyMode=true] Compat with legacy
  * @return {String}           Sanitized name
  */
-function sanitizeName(name = '') {
-    function toCamelCase(str) {
+function sanitizeName(name = '', legacyMode = true) {
+    function toCamelCase(str = '') {
+        str = str.replace(/[^\w\s]/g, ''); // Removes any non alphanumeric characters
+
+        if (legacyMode === false && /^([a-z]+)(([A-Z]([a-z]+))+)$/.test(str)) {
+            return str;
+        }
+
         // Lower cases the string
         return (
             str
             .toLowerCase()
             // Replaces any - or _ characters with a space
             .replace(/[-_]+/g, ' ')
-            // Removes any non alphanumeric characters
-            .replace(/[^\w\s]/g, '')
-            // Uppercases the first character in each group immediately following a space
+            // Uppercase the first character in each group immediately following a space
             // (delimited by spaces)
             .replace(/ (.)/g, function($1) {
                 return $1.toUpperCase();
@@ -79,11 +84,11 @@ function sanitizeName(name = '') {
     }
 
     function removeStartingDigits(name = '') {
-        return name.replace(/^[0-9]+/g, '');
+        return name.replace(/^[0-9]+[_\.]?/g, '');
     }
 
-    name = toCamelCase(name);
     name = removeStartingDigits(name);
+    name = toCamelCase(name);
 
     return name;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,10 +61,10 @@ function makeExcludeFilterFromWantList(options = {}) {
  */
 function sanitizeName(name = '', legacyMode = true) {
     function toCamelCase(str = '') {
-        str = str.replace(/[^\w\s]/g, ''); // Removes any non alphanumeric characters
 
-        if (legacyMode === false && /^([a-z]+)(([A-Z]([a-z]+))+)$/.test(str)) {
-            return str;
+        if (legacyMode === false) {
+            let test = str.replace(/[^\w\s]/g, '');
+            if (/^([a-z]+)(([A-Z]([a-z]+))+)$/.test(test)) return test;
         }
 
         // Lower cases the string
@@ -73,6 +73,8 @@ function sanitizeName(name = '', legacyMode = true) {
             .toLowerCase()
             // Replaces any - or _ characters with a space
             .replace(/[-_]+/g, ' ')
+            // Removes any non alphanumeric characters
+            .replace(/[^\w\s]/g, '')
             // Uppercase the first character in each group immediately following a space
             // (delimited by spaces)
             .replace(/ (.)/g, function($1) {
@@ -83,11 +85,10 @@ function sanitizeName(name = '', legacyMode = true) {
         );
     }
 
-    function removeStartingDigits(name = '') {
-        return name.replace(/^[0-9]+[_\.]?/g, '');
-    }
+    name = name.trim();
+    name = name.replace(/^[0-9]+/, '');
+    name = name.replace(/^[_-]/, '');
 
-    name = removeStartingDigits(name);
     name = toCamelCase(name);
 
     return name;

--- a/tests/utils-spec.js
+++ b/tests/utils-spec.js
@@ -11,12 +11,30 @@ const {
 // Application.DEFAULTS.autoinitialize = false;
 
 test('sanitizeName should camel case strings', (t) => {
-    t.equals(sanitizeName('data-manager'), 'dataManager', 'String sanitized.');
+    t.equals(sanitizeName('data-manager'), 'dataManager', 'data-manager = dataManager.');
+    t.equals(sanitizeName('01.first-command'), 'firstCommand', '01.first-command = firstCommand');
+    t.equals(sanitizeName('01_first-command'), 'firstCommand', '01_first-command = firstCommand');
     t.end();
 });
 
-test('sanitizeName should remove initial digits from name', (t) => {
-    t.equals(sanitizeName('01.first-command'), 'firstCommand', 'String sanitized.');
+test('sanitizeName should not respect camel case words in LEGACY mode', (t) => {
+    const useLegacy = true;
+    t.equals(sanitizeName('dataManager', useLegacy), 'datamanager', 'legacy: dataManager = datamanager');
+    t.equals(sanitizeName('01_dataManager!', useLegacy), 'datamanager', 'legacy: 01_dataManager! = datamanager');
+    t.equals(sanitizeName('dataManager🚀', useLegacy), 'datamanager', 'legacy: dataManager🚀 = datamanager');
+    t.equals(sanitizeName('01.dataManager', useLegacy), 'datamanager', 'legacy: 01.dataManager = datamanager');
+    t.end();
+});
+
+
+//############# BREAKING CHANGE
+test('sanitizeName should respect camel case words', (t) => {
+
+    t.equals(sanitizeName('dataManager', false), 'dataManager', 'dataManager = dataManager');
+    t.equals(sanitizeName('dataManager🚀', false), 'dataManager', 'dataManager🚀 = dataManager');
+    t.equals(sanitizeName('01.dataManager', false), 'dataManager', '01.dataManager = dataManager');
+    t.equals(sanitizeName('01_dataManager!', false), 'dataManager', '01_dataManager! = dataManager');
+
     t.end();
 });
 


### PR DESCRIPTION
This PR has a sketch for a deprecation helper.

```js
const context = {
    moduleid: 'test'
};

function markAsDeprecated(instance, attribute) {
    const old = instance[attribute];
    Object.defineProperty(instance, attribute, {
        get: function $get() {
            context.deprecationNotice(attribute, 'attribute');
            return old;
        },
    });
}

function functionUsingDeprecatedAttribute() {
    console.log('module id: %s', context.moduleid);
}


function main() {
    context.deprecationNotice = deprecationNotice;
    markAsDeprecated(context, 'moduleid');
    functionUsingDeprecatedAttribute();
}

function deprecationNotice(attribute, type) {
    let error = new DeprecationError(attribute, type);
    console.log(error.getSource());
    console.log(error.stack);
}

main();
```