### PR TITLE
Update module load cycle

### DIFF
--- a/docs/06_COMMANDS.md
+++ b/docs/06_COMMANDS.md
@@ -6,13 +6,13 @@ template: "index"
 
 ## Commands
 
-Commands are meant to encapsulate your business logic in a tightly bounded scope and executed by triggering an event. Commands are placed in the `./commands` directory of your project and are autoloaded during the application boot sequence. To trigger a command you emit an event using the **core.io** context, if the event type matches a file name then the handler exposed by it's module will be executed.
+Commands are meant to encapsulate your business logic in a tightly bounded scope and executed by triggering an event. Commands are placed in the `./commands` directory of your project and are autoloaded during the application boot sequence. To trigger a command you dispatch an event using the **core.io** context, if the event type matches a file name then the handler exposed by it's module will be executed.
 
 ### Handler
 
 Commands are exposed as modules, so each command is mapped to a file. The module can expose the command as a function or as a class.
 
-Command handlers can be either sync that return a promise  or `async` functions. 
+Command handlers can be either sync that return a promise  or `async` functions.
 
 Command exposed as a function :
 
@@ -40,7 +40,7 @@ class GreetCommand {
         const context = event.context;
         const logger = context.getLogger('greet-cmd');
         logger.info('Executing greet command');
-    
+
         return {
             message: `Hello ${event.name}!`
         };
@@ -53,7 +53,7 @@ module.exports = HelloCommand;
 To dispatch this command:
 
 ```js
-context.emit('hello', {name: 'Peperone'});
+context.dispatch('hello', {name: 'Peperone'});
 ```
 
 ### Event
@@ -99,7 +99,7 @@ context.once('hello.error', res => {
     console.error('message: %s', res.message);
 });
 
-context.emit('hello', {
+context.dispatch('hello', {
     name: 'Peperone',
     respondTo(res, error) {
         console.info('response: %s', res.message);
@@ -117,7 +117,7 @@ The `respondTo` callback takes two arguments, a `res` object that will be whatev
 To dispatch this command:
 
 ```js
-context.emit('hello', {
+context.dispatch('hello', {
     name: 'Peperone',
     respondTo: function(res, error) {
         console.log('message: %s', res.message);

--- a/examples/commands/context.ready.js
+++ b/examples/commands/context.ready.js
@@ -1,0 +1,17 @@
+'use strict';
+
+
+class ContextReadyCommand {
+    execute(event) {
+        const context = event.context;
+        const logger = context.getLogger('app-run');
+        logger.info('Context ready command...');
+        context.dispatch('media.upload');
+        context.dispatch('media.list');
+    }
+
+}
+
+ContextReadyCommand.ID = 'ContextReadyCommand';
+
+module.exports = ContextReadyCommand;

--- a/examples/commands/media.upload.js
+++ b/examples/commands/media.upload.js
@@ -2,8 +2,10 @@
 
 class MediaUploadCommand {
 
-    execute(event){
-        event.context.getLogger('media').info('execute media upload command...');
+    execute(event) {
+        const logger = event.context.getLogger('media-upload');
+        logger.info('MediaListCommand execute...');
+        logger.info('execute media upload command...');
     }
 }
 

--- a/examples/config/app.js
+++ b/examples/config/app.js
@@ -4,6 +4,7 @@ module.exports = {
     banner,
     name: 'App Kernel',
     environment: process.env.NODE_ENV || 'development',
+    autoloadModulesCommands: true,
     loaders: {
         modules: './modules',
         commands: './commands'

--- a/examples/index.js
+++ b/examples/index.js
@@ -46,11 +46,6 @@ app.once('run.post', function() {
     app.logger.debug(this.nicename);
     app.logger.debug('--------');
 
-    console.log('------------------');
-    console.log('here, here, here');
-    console.log('------------------');
-
-    // let err = new Error('This is a sample error!!!');
     // app.logger.error(err.stack);
     const watcher = require('chokidar');
 
@@ -68,8 +63,44 @@ app.once('run.post', function() {
     });
 });
 
-app.once('coreplugins.ready', () => {
+
+/**
+ * Once the application has bootstraped
+ * then we can start the application.
+ * - coreplugins.ready (commands and plugins not loaded)
+ * - modules.ready
+ * - commands.ready
+ */
+app.once('modules.ready', _ => {
+    app.logger.info('modules ready!');
     app.run();
+});
+
+app.once('coreplugins.ready', () => {
+    app.logger.info('core modules resolved!');
+});
+
+app.once('modules.resolved', _ => {
+    app.logger.info('modules resolved!');
+});
+
+app.once('context.ready', _ => {
+
+    app.logger.warn('----------------------');
+    app.logger.info('app running');
+    app.logger.warn('----------------------');
+});
+
+app.once('media.registered', _ => {
+    app.logger.warn('----------------------');
+    app.logger.info('media.registered');
+    app.logger.warn('----------------------');
+});
+
+app.once('service.registered', _ => {
+    app.logger.warn('----------------------');
+    app.logger.info('service.registered');
+    app.logger.warn('----------------------');
 });
 
 function requireUncached(mdl) {

--- a/examples/modules/media/commands/media.list.js
+++ b/examples/modules/media/commands/media.list.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function MediaListCommand(event) {
+    const logger = event.context.getLogger('media-list');
+    logger.info('MediaListCommand execute...');
+}
+
+
+module.exports = MediaListCommand;

--- a/examples/modules/media/commands/media.upload.js
+++ b/examples/modules/media/commands/media.upload.js
@@ -1,9 +1,0 @@
-'use strict';
-
-function MediaUploadCommand(event) {
-    let logger = event.context.getLogger('media-upload');
-    logger.info('MediaUploadCommand execute...');
-}
-
-
-module.exports = MediaUploadCommand;

--- a/examples/modules/service/commands/service.start.js
+++ b/examples/modules/service/commands/service.start.js
@@ -1,0 +1,14 @@
+'use strict';
+
+
+class ServiceStartCommand {
+    execute(event) {
+        const context = event.context;
+        const logger = context.getLogger('svc-start');
+        logger.info('Service start command...');
+    }
+}
+
+ServiceStartCommand.ID = 'ServiceStartCommand';
+
+module.exports = ServiceStartCommand;

--- a/examples/modules/service/index.js
+++ b/examples/modules/service/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports.init = function(context, config) {
+    const logger = context.getLogger(config.moduleid);
+    logger.info('Service module start...');
+    return {};
+};

--- a/lib/application.js
+++ b/lib/application.js
@@ -610,7 +610,8 @@ class Application extends EventEmitter {
                  */
                 if (await context._moduleHasCommands(bean)) {
                     context._logger.warn('Plugin "%s" has commands', bean.id);
-                    this._commands.push(bean.path);
+                    context._commands.push(bean.path);
+                    await context._loadModuleExposedCommands();
                 }
 
                 return bean.plugin;
@@ -627,8 +628,6 @@ class Application extends EventEmitter {
                 return this.loadCommands(this.commandspath);
             }).then(_ => {
                 return this.loadModules(this.modulespath, this.loadModulesOptions);
-            }).then(_ => {
-                return this._loadModuleExposedCommands();
             })
             .catch(this.onErrorHandler.bind(this, true, 'Error loading plugin.'));
     }
@@ -736,9 +735,9 @@ class Application extends EventEmitter {
         if (instance.commands) {
             this._logger.warn('IMPLEMENT HANDLER FOR plugin.commands!');
             //our plugin exposes a bunch of command paths
-            // if(typeof instance.commands === 'string') instance.commands = [instance.commands];
-            // if(typeof instance.commands === 'function') instance.commands = instance.commands();
-            // this._commands = this._commands.concat(instance.commands);
+            if (typeof instance.commands === 'string') instance.commands = [instance.commands];
+            if (typeof instance.commands === 'function') instance.commands = instance.commands();
+            this._commands = this._commands.concat(instance.commands);
         }
 
         if (instance.models) {
@@ -1112,8 +1111,8 @@ class Application extends EventEmitter {
     _loadModuleExposedCommands() {
 
         if (!this.autoloadModulesCommands) {
-            this._logger.debug('Ignoring sub commands, you need to set config option');
-            this._logger.debug('autoloadModulesCommands in config/app.js to true');
+            this._logger.warn('Ignoring sub commands, you need to set config option');
+            this._logger.warn('autoloadModulesCommands in config/app.js to true');
             return Promise.resolve();
         }
 
@@ -1274,9 +1273,10 @@ class Application extends EventEmitter {
         this.didRun = true;
 
         // this.logger.profile('hook:run');
-        this.hook('run', { name: this.name }).then(_ => {
+        this.hook('run', { name: this.name }).then(async _ => {
             this._logger.debug('Hook "run" complete.');
-            this.registerApplication();
+            await this.registerApplication();
+            this.emit('context.ready');
         });
     }
 

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -7,7 +7,7 @@ const Promise = require('bluebird');
 
 /**
  * Adds Event management methods to `Application`.
- * 
+ *
  * @memberof core/dispatcher
  * @param {Application} context Application context
  * @param {Object} config Configuration Object
@@ -28,10 +28,7 @@ module.exports.init = function(context, config) {
 
     context.getLogger('dispatcher').info('Module "dispatcher" ready...');
 
-    /**
-     * @TODO This is not necessary! remove
-     */
-    context.emit('dispatcher.ready');
+    context.provide('dispatch', context.emit.bind(context));
 
     return emitter;
 };
@@ -131,7 +128,7 @@ function createHook(emitter, config) {
  * Function wraps emitter with a chainEvent function.
  * A chain event will listen for a list of events and
  * resolve when all are triggered.
- * 
+ *
  * @memberof core/dispatcher
  * @param  {Object} emitter EventEmitter
  * @return {Function}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gkeypath": "^0.13.0",
     "glob": "7.2",
     "human-time": "0.0.2",
-    "in": "^0.18.2",
+    "in": "^0.19.0",
     "longjohn": "^0.2.12",
     "node-fetch": "^2.6.6",
     "noop-console": "^0.9.0",


### PR DESCRIPTION
This PR updates `in` with a fix to a bug that prevented context to notify when all modules where actually done loading.

* `context` now dispatches a `context.ready` event when all modules are loaded, resolved and ready to go.
* we now load commands found in modules command directory.
* `context.dispatch` is now preferred way to emit command events. (Closes #9)