### PR TITLE
Fix closing function

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1525,6 +1525,9 @@ class Application extends EventEmitter {
      * @return {Promise}
      */
     close(code, label) {
+        if (this.closing) return;
+        this.closing = true;
+
         /**
          * here we could run a close routing.
          * Whatever it is, it should not take

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -68,7 +68,7 @@ module.exports.init = function(app, config) {
          * Here we stll might have 10 seconds to go, or whatever
          * is Serene's timeout value.
          */
-        app.close(code, label).then(function() {
+        Promise.resolve(app.close(code, label)).then(function() {
 
             app.logger.warn('\nCLEANUP reason : %s code: %s', label, code);
 


### PR DESCRIPTION
* Ensure we have a promise as output of `app.close` in error handler.
* Ensure we do not call `close` twice.