### PR TITLE
Only bind function commands

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -1373,9 +1373,19 @@ class Application extends EventEmitter {
 
         if (!id) id = this.getUid();
 
+        //TODO: Implement options for command. We would pass to command constructor
         let command = _normalizeCommandObject(handler);
 
-        handler = command.execute.bind(this);
+        /**
+         * Only bind functions to context.
+         * TODO: Deprecate!
+         */
+        if (handler.$isFunction && !handler.$binded) {
+            handler = command.execute.bind(this);
+            handler.$binded = true;
+        } else {
+            handler = command.execute;
+        }
 
         if (unique && this.hasCommand(eventType)) {
             this._logger.warn('- %s has a listener registered and marked as unique', eventType);

--- a/lib/application.js
+++ b/lib/application.js
@@ -1373,8 +1373,9 @@ class Application extends EventEmitter {
 
         if (!id) id = this.getUid();
 
-        //TODO: Implement options for command. We would pass to command constructor
-        let command = _normalizeCommandObject(handler);
+        //TODO: Implement options for command. We would pass to command constructor.
+        //app.config.get('commands.initParameters.eventType');
+        let command = _normalizeCommandObject(handler, {});
 
         /**
          * Only bind functions to context.
@@ -1384,7 +1385,11 @@ class Application extends EventEmitter {
             handler = command.execute.bind(this);
             handler.$binded = true;
         } else {
-            handler = command.execute;
+            /**
+             * Preverse context of command so we can
+             * access constructor, e.g. `this.constructor.SLUG`.
+             */
+            handler = e => command.execute(e);
         }
 
         if (unique && this.hasCommand(eventType)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,15 +162,16 @@ function normalizeCommandObject(command, config = {}) {
      * Check!!
      */
     return {
-        execute: command
+        execute: command,
+        $isFunction: true
     };
 }
 
 /**
- * Generate an unique identifier in 
+ * Generate an unique identifier in
  * the form or:
  * "jce1t9gu-sg69zzohk7"
- * 
+ *
  * @param {Number} len Output length
  * @return {String}
  */


### PR DESCRIPTION
This ensures that we only `bind` command function handlers to the app context. Else we ensure that the handler keeps its own context and class commands can access their constructor, e.g. `this.constructor.SLUG`.